### PR TITLE
Make temperature readings work without underflow on micros with 32-bi…

### DIFF
--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -228,7 +228,7 @@ void Adafruit_LSM6DS::fillTempEvent(sensors_event_t *temp, uint32_t timestamp) {
   temp->sensor_id = _sensorid_temp;
   temp->type = SENSOR_TYPE_AMBIENT_TEMPERATURE;
   temp->timestamp = timestamp;
-  temp->temperature = (temperature / 256.0) + 25.0;
+  temp->temperature = temperature;
 }
 
 void Adafruit_LSM6DS::fillGyroEvent(sensors_event_t *gyro, uint32_t timestamp) {
@@ -417,7 +417,8 @@ void Adafruit_LSM6DS::_read(void) {
   uint8_t buffer[14];
   data_reg.read(buffer, 14);
 
-  temperature = buffer[1] << 8 | buffer[0];
+  rawTemp = buffer[1] << 8 | buffer[0];
+  temperature = (rawTemp / 256.0) + 25.0;
 
   rawGyroX = buffer[3] << 8 | buffer[2];
   rawGyroY = buffer[5] << 8 | buffer[4];

--- a/Adafruit_LSM6DSO32.cpp
+++ b/Adafruit_LSM6DSO32.cpp
@@ -72,7 +72,8 @@ void Adafruit_LSM6DSO32::_read(void) {
   uint8_t buffer[14];
   data_reg.read(buffer, 14);
 
-  temperature = buffer[1] << 8 | buffer[0];
+  rawTemp = buffer[1] << 8 | buffer[0];
+  temperature = (rawTemp / 256.0) + 25.0;
 
   rawGyroX = buffer[3] << 8 | buffer[2];
   rawGyroY = buffer[5] << 8 | buffer[4];


### PR DESCRIPTION
Scope of change:

Make temperature readings below 25ºC work on microcontrollers with integers greater than 16 bits.
The existing code works on architectures where int is 16 bits wide, due to an implicit conversion of a uint_8 << 8 + uint_8 to integer.
When that int16 is negative on a 16-bit architecture (such as Arduino where it was originally written), it works.
What that quantity is negative on a 32-bit architecture (such as ESP32), then anytime that "would have been negative", it is instead 256ºC higher. 
As a result, when the device is cooled in 0.1ºC increments from 25.3ºC, the output is 25.3, 25.2, 25.1, 25.0, 280.9, 280.8, etc.

This patch fixes that bug and, in addition, sets the existing (previously unused) rawTemp private variable, consistent with how other raw sensor measurements are done.
