### PR TITLE
Add support for lsm6dsl

### DIFF
--- a/Adafruit_LSM6DSL.cpp
+++ b/Adafruit_LSM6DSL.cpp
@@ -1,0 +1,56 @@
+
+/*!
+ *  @file Adafruit_LSM6DSL.cpp Adafruit LSM6DSL 6-DoF Accelerometer
+ *  and Gyroscope library
+ *
+ *  Adapted by Eugene Anikin for Adafruit Industries
+ * 	BSD (see license.txt)
+ */
+
+#include "Arduino.h"
+#include <Wire.h>
+
+#include "Adafruit_LSM6DSL.h"
+
+/*!
+ *    @brief  Instantiates a new LSM6DSL class
+ */
+Adafruit_LSM6DSL::Adafruit_LSM6DSL(void) {}
+
+bool Adafruit_LSM6DSL::_init(int32_t sensor_id) {
+  // make sure we're talking to the right chip
+  if (chipID() != LSM6DSL_CHIP_ID) {
+    return false;
+  }
+  _sensorid_accel = sensor_id;
+  _sensorid_gyro = sensor_id + 1;
+  _sensorid_temp = sensor_id + 2;
+
+  reset();
+
+  // enable accelerometer and gyro by setting the data rate to non-zero
+  setAccelDataRate(LSM6DS_RATE_104_HZ);
+  setGyroDataRate(LSM6DS_RATE_104_HZ);
+
+  delay(10);
+
+  temp_sensor = new Adafruit_LSM6DS_Temp(this);
+  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
+  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+
+  return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief Enables and disables the I2C master bus pulllups.
+    @param enable_pullups true to enable the I2C pullups, false to disable.
+*/
+void Adafruit_LSM6DSL::enableI2CMasterPullups(bool enable_pullups) {
+  Adafruit_BusIO_Register master_config = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DSL_MASTER_CONFIG);
+  Adafruit_BusIO_RegisterBits i2c_master_pu_en =
+      Adafruit_BusIO_RegisterBits(&master_config, 1, 3);
+
+  i2c_master_pu_en.write(enable_pullups);
+}

--- a/Adafruit_LSM6DSL.h
+++ b/Adafruit_LSM6DSL.h
@@ -1,0 +1,42 @@
+/*!
+ *  @file Adafruit_LSM6DSL.h
+ *
+ * 	I2C Driver for the Adafruit LSM6DSL 6-DoF Accelerometer and Gyroscope
+ *library
+ *
+ * 	This is a library for the Adafruit LSM6DSL breakout:
+ * 	https://www.adafruit.com/
+ *
+ * 	Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit and open-source hardware by purchasing products from
+ * 	Adafruit!
+ *
+ *
+ *	BSD license (see license.txt)
+ */
+
+#ifndef _ADAFRUIT_LSM6DSL_H
+#define _ADAFRUIT_LSM6DSL_H
+
+#include "Adafruit_LSM6DS.h"
+
+#define LSM6DSL_CHIP_ID 0x6A ///< LSM6DSL default device id from WHOAMI
+
+#define LSM6DSL_MASTER_CONFIG 0x1A ///< I2C Master config
+
+/*!
+ *    @brief  Class that stores state and functions for interacting with
+ *            the LSM6DSL
+ */
+class Adafruit_LSM6DSL : public Adafruit_LSM6DS {
+public:
+  Adafruit_LSM6DSL();
+  ~Adafruit_LSM6DSL(){};
+
+  void enableI2CMasterPullups(bool enable_pullups);
+
+private:
+  bool _init(int32_t sensor_id);
+};
+
+#endif


### PR DESCRIPTION
lsm6dsl uses same protocol as other chips in its family. Copied code from DS3 and adjusted CHIP_ID. Works well on my board.