### PR TITLE
Support Arduino API

### DIFF
--- a/Adafruit_ISM330DHCX.cpp
+++ b/Adafruit_ISM330DHCX.cpp
@@ -28,15 +28,8 @@ bool Adafruit_ISM330DHCX::_init(int32_t sensor_id) {
 
   reset();
 
-  // enable accelerometer and gyro by setting the data rate to non-zero
-  setAccelDataRate(LSM6DS_RATE_104_HZ);
-  setGyroDataRate(LSM6DS_RATE_104_HZ);
-
-  delay(10);
-
-  temp_sensor = new Adafruit_LSM6DS_Temp(this);
-  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
-  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+  // call base class _init()
+  Adafruit_LSM6DS::_init(sensor_id);
 
   return true;
 }

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -787,7 +787,7 @@ int Adafruit_LSM6DS::readAcceleration(float &x, float &y, float &z) {
 
   busio->setAddress(LSM6DS_OUTX_L_A);
 
-  if (! busio->read((uint8_t *) data, sizeof(data))) {
+  if (!busio->read((uint8_t *)data, sizeof(data))) {
     x = y = z = NAN;
     return 0;
   }
@@ -828,7 +828,7 @@ int Adafruit_LSM6DS::readGyroscope(float &x, float &y, float &z) {
 
   busio->setAddress(LSM6DS_OUTX_L_G);
 
-  if (! busio->read((uint8_t *) data, sizeof(data))) {
+  if (!busio->read((uint8_t *)data, sizeof(data))) {
     x = y = z = NAN;
     return 0;
   }

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -799,6 +799,9 @@ int Adafruit_LSM6DS::accelerationAvailable(void) {
 /**************************************************************************/
 /*!
     @brief Read accelerometer data
+    @param x reference to x axis
+    @param y reference to y axis
+    @param z reference to z axis
     @returns 1 if success, 0 if not
 */
 int Adafruit_LSM6DS::readAcceleration(float &x, float &y, float &z) {
@@ -839,7 +842,10 @@ int Adafruit_LSM6DS::gyroscopeAvailable(void) {
 
 /**************************************************************************/
 /*!
-    @brief Read accelerometer data
+    @brief Read gyroscope data
+    @param x reference to x axis
+    @param y reference to y axis
+    @param z reference to z axis
     @returns 1 if success, 0 if not
 */
 int Adafruit_LSM6DS::readGyroscope(float &x, float &y, float &z) {

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -63,6 +63,21 @@ Adafruit_LSM6DS::~Adafruit_LSM6DS(void) {
  */
 bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
   (void)sensor_id;
+
+  // Enable accelerometer with 104 Hz data rate, 4G
+  setAccelDataRate(LSM6DS_RATE_104_HZ);
+  setAccelRange(LSM6DS_ACCEL_RANGE_4_G);
+
+  // Enable gyro with 104 Hz data rate, 2000 dps
+  setGyroDataRate(LSM6DS_RATE_104_HZ);
+  setGyroRange(LSM6DS_GYRO_RANGE_2000_DPS);
+
+  delay(10);
+
+  temp_sensor = new Adafruit_LSM6DS_Temp(this);
+  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
+  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+
   return false;
 };
 

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -61,7 +61,10 @@ Adafruit_LSM6DS::~Adafruit_LSM6DS(void) {
  *   @param sensor_id Optional unique ID for the sensor set
  *   @returns True if chip identified and initialized
  */
-bool Adafruit_LSM6DS::_init(int32_t sensor_id) { return false; };
+bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
+  (void)sensor_id;
+  return false;
+};
 
 /*!
  *    @brief  Read chip identification register
@@ -595,7 +598,7 @@ bool Adafruit_LSM6DS_Gyro::getEvent(sensors_event_t *event) {
 /*!
     @brief  Gets the sensor_t data for the LSM6DS's accelerometer
 */
-/****************************************************************_data_rate_arr**********/
+/**************************************************************************/
 void Adafruit_LSM6DS_Accelerometer::getSensor(sensor_t *sensor) {
   /* Clear the sensor_t object */
   memset(sensor, 0, sizeof(sensor_t));

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -210,7 +210,8 @@ void Adafruit_LSM6DS::reset(void) {
   Adafruit_BusIO_RegisterBits sw_reset =
       Adafruit_BusIO_RegisterBits(&ctrl3, 1, 0);
 
-  Adafruit_BusIO_RegisterBits boot = Adafruit_BusIO_RegisterBits(&ctrl3, 1, 7);
+  // Adafruit_BusIO_RegisterBits boot = Adafruit_BusIO_RegisterBits(&ctrl3, 1,
+  // 7);
 
   sw_reset.write(true);
 
@@ -780,7 +781,7 @@ uint16_t Adafruit_LSM6DS::readPedometer(void) {
 /**************************************************************************/
 /*!
     @brief Gets the accelerometer data rate.
-    @returns The accelerometer data rate in float
+    @returns The data rate in float
 */
 float Adafruit_LSM6DS::accelerationSampleRate(void) {
   return _data_rate_arr[this->getAccelDataRate()];
@@ -820,8 +821,8 @@ int Adafruit_LSM6DS::readAcceleration(float &x, float &y, float &z) {
 
 /**************************************************************************/
 /*!
-    @brief Gets the gyroscope data rate.
-    @returns The gyroscope data rate in float
+    @brief Get the gyroscope data rate.
+    @returns The data rate in float
 */
 float Adafruit_LSM6DS::gyroscopeSampleRate(void) {
   return _data_rate_arr[this->getGyroDataRate()];

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -86,11 +86,12 @@ bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
  *    @returns 8 Bit value from WHOAMI register
  */
 uint8_t Adafruit_LSM6DS::chipID(void) {
-  busio->setAddress(LSM6DS_WHOAMI);
+  Adafruit_BusIO_Register chip_id = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_WHOAMI);
   // Serial.print("Read ID 0x"); Serial.println(chip_id.read(), HEX);
 
   // make sure we're talking to the right chip
-  return busio->read();
+  return chip_id.read();
 }
 
 /*!
@@ -98,8 +99,9 @@ uint8_t Adafruit_LSM6DS::chipID(void) {
  *    @returns 8 Bit value from Status register
  */
 uint8_t Adafruit_LSM6DS::status(void) {
-  busio->setAddress(LSM6DS_STATUS_REG);
-  return busio->read();
+  Adafruit_BusIO_Register status_reg = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_STATUS_REG);
+  return status_reg.read();
 }
 
 /*!
@@ -121,11 +123,6 @@ boolean Adafruit_LSM6DS::begin_I2C(uint8_t i2c_address, TwoWire *wire,
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 
   if (!i2c_dev->begin()) {
-    return false;
-  }
-
-  busio = new Adafruit_BusIO_Register(i2c_dev, 0x0000);
-  if (!busio) {
     return false;
   }
 
@@ -156,11 +153,6 @@ bool Adafruit_LSM6DS::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
     return false;
   }
 
-  busio = new Adafruit_BusIO_Register(spi_dev, 0x0000, ADDRBIT8_HIGH_TOREAD);
-  if (!busio) {
-    return false;
-  }
-
   return _init(sensor_id);
 }
 
@@ -186,11 +178,6 @@ bool Adafruit_LSM6DS::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
                                    SPI_BITORDER_MSBFIRST, // bit order
                                    SPI_MODE0);            // data mode
   if (!spi_dev->begin()) {
-    return false;
-  }
-
-  busio = new Adafruit_BusIO_Register(spi_dev, 0x0000, ADDRBIT8_HIGH_TOREAD);
-  if (!busio) {
     return false;
   }
 
@@ -807,9 +794,10 @@ int Adafruit_LSM6DS::accelerationAvailable(void) {
 int Adafruit_LSM6DS::readAcceleration(float &x, float &y, float &z) {
   int16_t data[3];
 
-  busio->setAddress(LSM6DS_OUTX_L_A);
+  Adafruit_BusIO_Register accel_data = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_OUTX_L_A, 6);
 
-  if (!busio->read((uint8_t *)data, sizeof(data))) {
+  if (!accel_data.read((uint8_t *)data, sizeof(data))) {
     x = y = z = NAN;
     return 0;
   }
@@ -851,9 +839,10 @@ int Adafruit_LSM6DS::gyroscopeAvailable(void) {
 int Adafruit_LSM6DS::readGyroscope(float &x, float &y, float &z) {
   int16_t data[3];
 
-  busio->setAddress(LSM6DS_OUTX_L_G);
+  Adafruit_BusIO_Register gyro_data = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_OUTX_L_G, 6);
 
-  if (!busio->read((uint8_t *)data, sizeof(data))) {
+  if (!gyro_data.read((uint8_t *)data, sizeof(data))) {
     x = y = z = NAN;
     return 0;
   }

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -176,6 +176,16 @@ public:
   void enablePedometer(bool enable);
   void resetPedometer(void);
   uint16_t readPedometer(void);
+
+  // Arduino compatible API
+  int readAcceleration(float &x, float &y, float &z);
+  float accelerationSampleRate(void);
+  int accelerationAvailable(void);
+
+  int readGyroscope(float &x, float &y, float &z);
+  float gyroscopeSampleRate(void);
+  int gyroscopeAvailable(void);
+
   int16_t rawAccX, ///< Last reading's raw accelerometer X axis
       rawAccY,     ///< Last reading's raw accelerometer Y axis
       rawAccZ,     ///< Last reading's raw accelerometer Z axis
@@ -187,15 +197,6 @@ public:
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getAccelerometerSensor(void);
   Adafruit_Sensor *getGyroSensor(void);
-
-  // Arduino compatible API
-  int readAcceleration(float &x, float &y, float &z);
-  float accelerationSampleRate(void);
-  int accelerationAvailable(void);
-
-  int readGyroscope(float &x, float &y, float &z);
-  float gyroscopeSampleRate(void);
-  int gyroscopeAvailable(void);
 
 protected:
   float temperature, ///< Last reading's temperature (C)

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -139,7 +139,7 @@ private:
 class Adafruit_LSM6DS {
 public:
   Adafruit_LSM6DS();
-  ~Adafruit_LSM6DS();
+  virtual ~Adafruit_LSM6DS();
 
   bool begin_I2C(uint8_t i2c_addr = LSM6DS_I2CADDR_DEFAULT,
                  TwoWire *wire = &Wire, int32_t sensorID = 0);

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -215,9 +215,8 @@ protected:
       _sensorid_gyro,       ///< ID number for gyro
       _sensorid_temp;       ///< ID number for temperature
 
-  Adafruit_I2CDevice *i2c_dev = NULL;    ///< Pointer to I2C bus interface
-  Adafruit_SPIDevice *spi_dev = NULL;    ///< Pointer to SPI bus interface
-  Adafruit_BusIO_Register *busio = NULL; ///< Pointer to BusIO object
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
 
   Adafruit_LSM6DS_Temp *temp_sensor = NULL; ///< Temp sensor data object
   Adafruit_LSM6DS_Accelerometer *accel_sensor =

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -32,6 +32,7 @@
 #define LSM6DS_CTRL8_XL 0x17       ///< High and low pass for accel
 #define LSM6DS_CTRL10_C 0x19       ///< Main configuration register
 #define LSM6DS_WAKEUP_SRC 0x1B     ///< Why we woke up
+#define LSM6DS_STATUS_REG 0X1E     ///< Status register
 #define LSM6DS_OUT_TEMP_L 0x20     ///< First data register (temperature low)
 #define LSM6DS_OUTX_L_G 0x22       ///< First gyro data register
 #define LSM6DS_OUTX_L_A 0x28       ///< First accel data register
@@ -187,6 +188,15 @@ public:
   Adafruit_Sensor *getAccelerometerSensor(void);
   Adafruit_Sensor *getGyroSensor(void);
 
+  // Arduino compatible API
+  int readAcceleration(float &x, float &y, float &z);
+  float accelerationSampleRate(void);
+  int accelerationAvailable(void);
+
+  int readGyroscope(float &x, float &y, float &z);
+  float gyroscopeSampleRate(void);
+  int gyroscopeAvailable(void);
+
 protected:
   float temperature, ///< Last reading's temperature (C)
       accX,          ///< Last reading's accelerometer X axis m/s^2
@@ -195,7 +205,8 @@ protected:
       gyroX,         ///< Last reading's gyro X axis in rad/s
       gyroY,         ///< Last reading's gyro Y axis in rad/s
       gyroZ;         ///< Last reading's gyro Z axis in rad/s
-  uint8_t chipID();
+  uint8_t chipID(void);
+  uint8_t status(void);
   virtual void _read(void);
   virtual bool _init(int32_t sensor_id);
 
@@ -205,6 +216,7 @@ protected:
 
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
+  Adafruit_BusIO_Register *busio = NULL;
 
   Adafruit_LSM6DS_Temp *temp_sensor = NULL; ///< Temp sensor data object
   Adafruit_LSM6DS_Accelerometer *accel_sensor =

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -215,9 +215,9 @@ protected:
       _sensorid_gyro,       ///< ID number for gyro
       _sensorid_temp;       ///< ID number for temperature
 
-  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
-  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
-  Adafruit_BusIO_Register *busio = NULL;
+  Adafruit_I2CDevice *i2c_dev = NULL;    ///< Pointer to I2C bus interface
+  Adafruit_SPIDevice *spi_dev = NULL;    ///< Pointer to SPI bus interface
+  Adafruit_BusIO_Register *busio = NULL; ///< Pointer to BusIO object
 
   Adafruit_LSM6DS_Temp *temp_sensor = NULL; ///< Temp sensor data object
   Adafruit_LSM6DS_Accelerometer *accel_sensor =

--- a/Adafruit_LSM6DS3.cpp
+++ b/Adafruit_LSM6DS3.cpp
@@ -28,15 +28,8 @@ bool Adafruit_LSM6DS3::_init(int32_t sensor_id) {
 
   reset();
 
-  // enable accelerometer and gyro by setting the data rate to non-zero
-  setAccelDataRate(LSM6DS_RATE_104_HZ);
-  setGyroDataRate(LSM6DS_RATE_104_HZ);
-
-  delay(10);
-
-  temp_sensor = new Adafruit_LSM6DS_Temp(this);
-  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
-  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+  // call base class _init()
+  Adafruit_LSM6DS::_init(sensor_id);
 
   return true;
 }

--- a/Adafruit_LSM6DS33.cpp
+++ b/Adafruit_LSM6DS33.cpp
@@ -31,15 +31,8 @@ bool Adafruit_LSM6DS33::_init(int32_t sensor_id) {
     return false;
   }
 
-  // enable accelerometer and gyro by setting the data rate to non-zero
-  setAccelDataRate(LSM6DS_RATE_104_HZ);
-  setGyroDataRate(LSM6DS_RATE_104_HZ);
-
-  delay(10);
-
-  temp_sensor = new Adafruit_LSM6DS_Temp(this);
-  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
-  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+  // call base class _init()
+  Adafruit_LSM6DS::_init(sensor_id);
 
   return true;
 }

--- a/Adafruit_LSM6DSL.cpp
+++ b/Adafruit_LSM6DSL.cpp
@@ -28,15 +28,8 @@ bool Adafruit_LSM6DSL::_init(int32_t sensor_id) {
 
   reset();
 
-  // enable accelerometer and gyro by setting the data rate to non-zero
-  setAccelDataRate(LSM6DS_RATE_104_HZ);
-  setGyroDataRate(LSM6DS_RATE_104_HZ);
-
-  delay(10);
-
-  temp_sensor = new Adafruit_LSM6DS_Temp(this);
-  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
-  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+  // call base class _init()
+  Adafruit_LSM6DS::_init(sensor_id);
 
   return true;
 }

--- a/Adafruit_LSM6DSO32.cpp
+++ b/Adafruit_LSM6DSO32.cpp
@@ -45,15 +45,8 @@ bool Adafruit_LSM6DSO32::_init(int32_t sensor_id) {
 
   i3c_disable_bit.write(true);
 
-  // enable accelerometer and gyro by setting the data rate to non-zero
-  setAccelDataRate(LSM6DS_RATE_104_HZ);
-  setGyroDataRate(LSM6DS_RATE_104_HZ);
-
-  delay(10);
-
-  temp_sensor = new Adafruit_LSM6DS_Temp(this);
-  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
-  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+  // call base class _init()
+  Adafruit_LSM6DS::_init(sensor_id);
 
   return true;
 }

--- a/Adafruit_LSM6DSOX.cpp
+++ b/Adafruit_LSM6DSOX.cpp
@@ -45,7 +45,7 @@ bool Adafruit_LSM6DSOX::_init(int32_t sensor_id) {
 
   i3c_disable_bit.write(true);
 
-  // Enable accelerometer with 104 Hz data rate,
+  // Enable accelerometer with 104 Hz data rate, 4G
   setAccelDataRate(LSM6DS_RATE_104_HZ);
   setAccelRange(LSM6DS_ACCEL_RANGE_4_G);
 

--- a/Adafruit_LSM6DSOX.cpp
+++ b/Adafruit_LSM6DSOX.cpp
@@ -31,6 +31,7 @@ bool Adafruit_LSM6DSOX::_init(int32_t sensor_id) {
 
   reset();
 
+  // Block Data Update
   Adafruit_BusIO_Register ctrl3 = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DSOX_CTRL3_C);
   Adafruit_BusIO_RegisterBits bdu = Adafruit_BusIO_RegisterBits(&ctrl3, 1, 6);
@@ -44,9 +45,13 @@ bool Adafruit_LSM6DSOX::_init(int32_t sensor_id) {
 
   i3c_disable_bit.write(true);
 
-  // enable accelerometer and gyro by setting the data rate to non-zero
+  // Enable accelerometer with 104 Hz data rate,
   setAccelDataRate(LSM6DS_RATE_104_HZ);
+  setAccelRange(LSM6DS_ACCEL_RANGE_4_G);
+
+  // Enable gyro with 104 Hz data rate, 2000 dps
   setGyroDataRate(LSM6DS_RATE_104_HZ);
+  setGyroRange(LSM6DS_GYRO_RANGE_2000_DPS);
 
   delay(10);
 

--- a/Adafruit_LSM6DSOX.cpp
+++ b/Adafruit_LSM6DSOX.cpp
@@ -45,19 +45,8 @@ bool Adafruit_LSM6DSOX::_init(int32_t sensor_id) {
 
   i3c_disable_bit.write(true);
 
-  // Enable accelerometer with 104 Hz data rate, 4G
-  setAccelDataRate(LSM6DS_RATE_104_HZ);
-  setAccelRange(LSM6DS_ACCEL_RANGE_4_G);
-
-  // Enable gyro with 104 Hz data rate, 2000 dps
-  setGyroDataRate(LSM6DS_RATE_104_HZ);
-  setGyroRange(LSM6DS_GYRO_RANGE_2000_DPS);
-
-  delay(10);
-
-  temp_sensor = new Adafruit_LSM6DS_Temp(this);
-  accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
-  gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
+  // call base class _init()
+  Adafruit_LSM6DS::_init(sensor_id);
 
   return true;
 }


### PR DESCRIPTION
This PR add Arduino compatible API as https://github.com/arduino-libraries/Arduino_LSM6DSOX/blob/master/src/LSM6DSOX.h#L34

This allow for sketch that run on arduino sensonr/platform can be easily migrated to use with Adafruit Sensor (e.g https://experiments.withgoogle.com/tiny-motion-trainer)

```C
  // Arduino compatible API
  int readAcceleration(float &x, float &y, float &z);
  float accelerationSampleRate(void);
  int accelerationAvailable(void);

  int readGyroscope(float &x, float &y, float &z);
  float gyroscopeSampleRate(void);
  int gyroscopeAvailable(void);
```

PS: written fashion that requires https://github.com/adafruit/Adafruit_BusIO/pull/46, therefore this is submitted as draft for now