### PR TITLE
Fix temperature calculation

### DIFF
--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -456,7 +456,7 @@ void Adafruit_LSM6DS::_read(void) {
   data_reg.read(buffer, 14);
 
   rawTemp = buffer[1] << 8 | buffer[0];
-  temperature = (rawTemp / 256.0) + 25.0;
+  temperature = (rawTemp / 16.0) + 25.0;
 
   rawGyroX = buffer[3] << 8 | buffer[2];
   rawGyroY = buffer[5] << 8 | buffer[4];


### PR DESCRIPTION
The original division factor of 256 was wrong for LSM6DS33 and caused the temperature to only change very close to offset value of +25 deg C.
According to ST LSM6DS33 datasheet https://www.st.com/resource/en/datasheet/lsm6ds33.pdf page 18 Table 5 under TSen the correct divisor value of 16 is also given, although I have to admin this is not so clear as the unit is somewhat wrongly labeled LSB.
What ST here means is, 16 digits equates to 1 degree, resulting the raw value required to be divided with 16 to add to offset of 25 degrees Celsius.

I tested the changed code with Adafruit LSM6DS33 (Product ID: 4480) https://www.adafruit.com/product/4480 and it produces correct temperature output in degrees Celsius.

Just to give you another reference source, where 16 is used, have a look at:
https://os.mbed.com/users/bclaus/code/LSM6DS33//file/4e7d663e26bd/LSM6DS33.cpp/
LSM6DS33.cpp line 124
