### PR TITLE
Fix Temperature Sensitivity

### DIFF
--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -456,7 +456,7 @@ void Adafruit_LSM6DS::_read(void) {
   data_reg.read(buffer, 14);
 
   rawTemp = buffer[1] << 8 | buffer[0];
-  temperature = (rawTemp / 256.0) + 25.0;
+  temperature = (rawTemp / temperature_sensitivity) + 25.0;
 
   rawGyroX = buffer[3] << 8 | buffer[2];
   rawGyroY = buffer[5] << 8 | buffer[4];

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -218,6 +218,7 @@ protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
 
+  float temperature_sensitivity = 256.0; ///< Temp sensor sensitivity in LSB/degC
   Adafruit_LSM6DS_Temp *temp_sensor = NULL; ///< Temp sensor data object
   Adafruit_LSM6DS_Accelerometer *accel_sensor =
       NULL;                                 ///< Accelerometer data object

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -218,7 +218,8 @@ protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
 
-  float temperature_sensitivity = 256.0; ///< Temp sensor sensitivity in LSB/degC
+  float temperature_sensitivity =
+      256.0; ///< Temp sensor sensitivity in LSB/degC
   Adafruit_LSM6DS_Temp *temp_sensor = NULL; ///< Temp sensor data object
   Adafruit_LSM6DS_Accelerometer *accel_sensor =
       NULL;                                 ///< Accelerometer data object

--- a/Adafruit_LSM6DS3.cpp
+++ b/Adafruit_LSM6DS3.cpp
@@ -26,6 +26,8 @@ bool Adafruit_LSM6DS3::_init(int32_t sensor_id) {
   _sensorid_gyro = sensor_id + 1;
   _sensorid_temp = sensor_id + 2;
 
+  temperature_sensitivity = 16.0;
+
   reset();
 
   // call base class _init()

--- a/Adafruit_LSM6DS33.cpp
+++ b/Adafruit_LSM6DS33.cpp
@@ -26,6 +26,8 @@ bool Adafruit_LSM6DS33::_init(int32_t sensor_id) {
   _sensorid_gyro = sensor_id + 1;
   _sensorid_temp = sensor_id + 2;
 
+  temperature_sensitivity = 16.0;
+
   reset();
   if (chipID() != LSM6DS33_CHIP_ID) {
     return false;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit LSM6DS
-version=4.3.0
+version=4.3.1
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the LSM6DS sensors in the Adafruit shop


### PR DESCRIPTION
For #24. Also see discussion in #23.

The 25 degC offset was sort of hiding this one, making incorrect readings look at least somewhat normal.

**EDIT** forgot to mention the test - output below is running `lsm6ds33_test.ino` example from library on Itsy M4 with a [PID 4485](https://www.adafruit.com/product/4485) breakout.

**BEFORE** (temperature seems reasonable)
![Screenshot from 2021-08-07 11-34-29](https://user-images.githubusercontent.com/8755041/128610703-e90ea706-7f3a-4b43-a679-86d31bea2f7d.png)

**AFTER** (agrees much better with ambient)
![Screenshot from 2021-08-07 11-34-48](https://user-images.githubusercontent.com/8755041/128610708-0d8c9344-d3e6-4b47-a094-3a79e1f9a65f.png)
