### PR TITLE
Fix repeated memory allocations upon sensor reinitialization

### DIFF
--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -74,11 +74,14 @@ bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
 
   delay(10);
 
-  // Check for and delete objects to avoid repeated memory allocations 
+  // Check for and delete objects to avoid repeated memory allocations
   // if sensor is reinitialized
-  if (temp_sensor) delete temp_sensor;
-  if (accel_sensor) delete accel_sensor;
-  if (gyro_sensor) delete gyro_sensor;
+  if (temp_sensor)
+    delete temp_sensor;
+  if (accel_sensor)
+    delete accel_sensor;
+  if (gyro_sensor)
+    delete gyro_sensor;
     
   temp_sensor = new Adafruit_LSM6DS_Temp(this);
   accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -82,7 +82,7 @@ bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
     delete accel_sensor;
   if (gyro_sensor)
     delete gyro_sensor;
-    
+
   temp_sensor = new Adafruit_LSM6DS_Temp(this);
   accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
   gyro_sensor = new Adafruit_LSM6DS_Gyro(this);

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -74,6 +74,12 @@ bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
 
   delay(10);
 
+  // Check for and delete objects to avoid repeated memory allocations 
+  // if sensor is reinitialized
+  if (temp_sensor) delete temp_sensor;
+  if (accel_sensor) delete accel_sensor;
+  if (gyro_sensor) delete gyro_sensor;
+    
   temp_sensor = new Adafruit_LSM6DS_Temp(this);
   accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
   gyro_sensor = new Adafruit_LSM6DS_Gyro(this);


### PR DESCRIPTION
Hi folks, 

This minor pull request fixes the issue identified in #28, where repeated calls to 'lsm6ds33.begin_I2C();' would result in new memory allocations and eventually cause the stack to crash.

A simple fix was suggested by @caternuson to check for and delete the `temp_sensor`, `accel_sensor` and `gyro_sensor` objects prior to allocating new memory. The library was tested with this change and it is confirmed that the amount of free ram on a SAMD21-based Adafruit microcontroller remained constant throughout several dozen reinitializations.

Happy to know if there's a more eloquent way to achieve the same result!

Cheers,
Adam