### PR TITLE
some performance improvements and code cleanups

### DIFF
--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -142,19 +142,20 @@ boolean Adafruit_LSM6DS::begin_I2C(uint8_t i2c_address, TwoWire *wire,
  *    @brief  Sets up the hardware and initializes hardware SPI
  *    @param  cs_pin The arduino pin # connected to chip select
  *    @param  theSPI The SPI object to be used for SPI connections.
+ *    @param  frequency The SPI bus frequency
  *    @param  sensor_id
  *            The user-defined ID to differentiate different sensors
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_LSM6DS::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
-                                int32_t sensor_id) {
+                                uint32_t frequency, int32_t sensor_id) {
   i2c_dev = NULL;
 
   if (spi_dev) {
     delete spi_dev; // remove old interface
   }
   spi_dev = new Adafruit_SPIDevice(cs_pin,
-                                   1000000,               // frequency
+                                   frequency,             // frequency
                                    SPI_BITORDER_MSBFIRST, // bit order
                                    SPI_MODE0,             // data mode
                                    theSPI);
@@ -171,19 +172,21 @@ bool Adafruit_LSM6DS::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
  *    @param  sck_pin The arduino pin # connected to SPI clock
  *    @param  miso_pin The arduino pin # connected to SPI MISO
  *    @param  mosi_pin The arduino pin # connected to SPI MOSI
+ *    @param  frequency The SPI bus frequency
  *    @param  sensor_id
  *            The user-defined ID to differentiate different sensors
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_LSM6DS::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                                int8_t mosi_pin, int32_t sensor_id) {
+                                int8_t mosi_pin, uint32_t frequency,
+                                int32_t sensor_id) {
   i2c_dev = NULL;
 
   if (spi_dev) {
     delete spi_dev; // remove old interface
   }
   spi_dev = new Adafruit_SPIDevice(cs_pin, sck_pin, miso_pin, mosi_pin,
-                                   1000000,               // frequency
+                                   frequency,             // frequency
                                    SPI_BITORDER_MSBFIRST, // bit order
                                    SPI_MODE0);            // data mode
   if (!spi_dev->begin()) {

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -139,7 +139,7 @@ boolean Adafruit_LSM6DS::begin_I2C(uint8_t i2c_address, TwoWire *wire,
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_LSM6DS::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
-                                uint32_t frequency, int32_t sensor_id) {
+                                int32_t sensor_id, uint32_t frequency) {
   i2c_dev = NULL;
 
   delete spi_dev; // remove old interface
@@ -168,8 +168,8 @@ bool Adafruit_LSM6DS::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_LSM6DS::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                                int8_t mosi_pin, uint32_t frequency,
-                                int32_t sensor_id) {
+                                int8_t mosi_pin, int32_t sensor_id,
+                                uint32_t frequency) {
   i2c_dev = NULL;
 
   delete spi_dev; // remove old interface

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -52,10 +52,7 @@ Adafruit_LSM6DS::Adafruit_LSM6DS(void) {}
 /*!
  *    @brief  Cleans up the LSM6DS
  */
-Adafruit_LSM6DS::~Adafruit_LSM6DS(void) {
-  if (temp_sensor)
-    delete temp_sensor;
-}
+Adafruit_LSM6DS::~Adafruit_LSM6DS(void) { delete temp_sensor; }
 
 /*!  @brief  Unique subclass initializer post i2c/spi init
  *   @param sensor_id Optional unique ID for the sensor set
@@ -74,14 +71,10 @@ bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
 
   delay(10);
 
-  // Check for and delete objects to avoid repeated memory allocations
-  // if sensor is reinitialized
-  if (temp_sensor)
-    delete temp_sensor;
-  if (accel_sensor)
-    delete accel_sensor;
-  if (gyro_sensor)
-    delete gyro_sensor;
+  // delete objects if sensor is reinitialized
+  delete temp_sensor;
+  delete accel_sensor;
+  delete gyro_sensor;
 
   temp_sensor = new Adafruit_LSM6DS_Temp(this);
   accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
@@ -125,9 +118,7 @@ uint8_t Adafruit_LSM6DS::status(void) {
  */
 boolean Adafruit_LSM6DS::begin_I2C(uint8_t i2c_address, TwoWire *wire,
                                    int32_t sensor_id) {
-  if (i2c_dev) {
-    delete i2c_dev; // remove old interface
-  }
+  delete i2c_dev; // remove old interface
 
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 
@@ -151,9 +142,8 @@ bool Adafruit_LSM6DS::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
                                 uint32_t frequency, int32_t sensor_id) {
   i2c_dev = NULL;
 
-  if (spi_dev) {
-    delete spi_dev; // remove old interface
-  }
+  delete spi_dev; // remove old interface
+
   spi_dev = new Adafruit_SPIDevice(cs_pin,
                                    frequency,             // frequency
                                    SPI_BITORDER_MSBFIRST, // bit order
@@ -182,9 +172,8 @@ bool Adafruit_LSM6DS::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
                                 int32_t sensor_id) {
   i2c_dev = NULL;
 
-  if (spi_dev) {
-    delete spi_dev; // remove old interface
-  }
+  delete spi_dev; // remove old interface
+
   spi_dev = new Adafruit_SPIDevice(cs_pin, sck_pin, miso_pin, mosi_pin,
                                    frequency,             // frequency
                                    SPI_BITORDER_MSBFIRST, // bit order

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -366,7 +366,6 @@ void Adafruit_LSM6DS::setAccelRange(lsm6ds_accel_range_t new_range) {
       Adafruit_BusIO_RegisterBits(&ctrl1, 2, 2);
 
   accel_range.write(new_range);
-  delay(20);
 }
 
 /**************************************************************************/
@@ -432,7 +431,6 @@ void Adafruit_LSM6DS::setGyroRange(lsm6ds_gyro_range_t new_range) {
       Adafruit_BusIO_RegisterBits(&ctrl2, 4, 0);
 
   gyro_range.write(new_range);
-  delay(20);
 }
 
 /**************************************************************************/

--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -350,7 +350,9 @@ lsm6ds_accel_range_t Adafruit_LSM6DS::getAccelRange(void) {
   Adafruit_BusIO_RegisterBits accel_range =
       Adafruit_BusIO_RegisterBits(&ctrl1, 2, 2);
 
-  return (lsm6ds_accel_range_t)accel_range.read();
+  accelRangeBuffered = (lsm6ds_accel_range_t)accel_range.read();
+
+  return accelRangeBuffered;
 }
 /**************************************************************************/
 /*!
@@ -366,6 +368,8 @@ void Adafruit_LSM6DS::setAccelRange(lsm6ds_accel_range_t new_range) {
       Adafruit_BusIO_RegisterBits(&ctrl1, 2, 2);
 
   accel_range.write(new_range);
+
+  accelRangeBuffered = new_range;
 }
 
 /**************************************************************************/
@@ -414,7 +418,9 @@ lsm6ds_gyro_range_t Adafruit_LSM6DS::getGyroRange(void) {
   Adafruit_BusIO_RegisterBits gyro_range =
       Adafruit_BusIO_RegisterBits(&ctrl2, 4, 0);
 
-  return (lsm6ds_gyro_range_t)gyro_range.read();
+  gyroRangeBuffered = (lsm6ds_gyro_range_t)gyro_range.read();
+
+  return gyroRangeBuffered;
 }
 
 /**************************************************************************/
@@ -431,6 +437,8 @@ void Adafruit_LSM6DS::setGyroRange(lsm6ds_gyro_range_t new_range) {
       Adafruit_BusIO_RegisterBits(&ctrl2, 4, 0);
 
   gyro_range.write(new_range);
+
+  gyroRangeBuffered = new_range;
 }
 
 /**************************************************************************/
@@ -476,35 +484,47 @@ void Adafruit_LSM6DS::_read(void) {
   rawAccY = buffer[11] << 8 | buffer[10];
   rawAccZ = buffer[13] << 8 | buffer[12];
 
-  lsm6ds_gyro_range_t gyro_range = getGyroRange();
   float gyro_scale = 1; // range is in milli-dps per bit!
-  if (gyro_range == ISM330DHCX_GYRO_RANGE_4000_DPS)
+  switch (gyroRangeBuffered) {
+  case ISM330DHCX_GYRO_RANGE_4000_DPS:
     gyro_scale = 140.0;
-  if (gyro_range == LSM6DS_GYRO_RANGE_2000_DPS)
+    break;
+  case LSM6DS_GYRO_RANGE_2000_DPS:
     gyro_scale = 70.0;
-  if (gyro_range == LSM6DS_GYRO_RANGE_1000_DPS)
+    break;
+  case LSM6DS_GYRO_RANGE_1000_DPS:
     gyro_scale = 35.0;
-  if (gyro_range == LSM6DS_GYRO_RANGE_500_DPS)
+    break;
+  case LSM6DS_GYRO_RANGE_500_DPS:
     gyro_scale = 17.50;
-  if (gyro_range == LSM6DS_GYRO_RANGE_250_DPS)
+    break;
+  case LSM6DS_GYRO_RANGE_250_DPS:
     gyro_scale = 8.75;
-  if (gyro_range == LSM6DS_GYRO_RANGE_125_DPS)
+    break;
+  case LSM6DS_GYRO_RANGE_125_DPS:
     gyro_scale = 4.375;
+    break;
+  }
 
   gyroX = rawGyroX * gyro_scale * SENSORS_DPS_TO_RADS / 1000.0;
   gyroY = rawGyroY * gyro_scale * SENSORS_DPS_TO_RADS / 1000.0;
   gyroZ = rawGyroZ * gyro_scale * SENSORS_DPS_TO_RADS / 1000.0;
 
-  lsm6ds_accel_range_t accel_range = getAccelRange();
   float accel_scale = 1; // range is in milli-g per bit!
-  if (accel_range == LSM6DS_ACCEL_RANGE_16_G)
+  switch (accelRangeBuffered) {
+  case LSM6DS_ACCEL_RANGE_16_G:
     accel_scale = 0.488;
-  if (accel_range == LSM6DS_ACCEL_RANGE_8_G)
+    break;
+  case LSM6DS_ACCEL_RANGE_8_G:
     accel_scale = 0.244;
-  if (accel_range == LSM6DS_ACCEL_RANGE_4_G)
+    break;
+  case LSM6DS_ACCEL_RANGE_4_G:
     accel_scale = 0.122;
-  if (accel_range == LSM6DS_ACCEL_RANGE_2_G)
+    break;
+  case LSM6DS_ACCEL_RANGE_2_G:
     accel_scale = 0.061;
+    break;
+  }
 
   accX = rawAccX * accel_scale * SENSORS_GRAVITY_STANDARD / 1000;
   accY = rawAccY * accel_scale * SENSORS_GRAVITY_STANDARD / 1000;

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -228,6 +228,11 @@ protected:
       NULL;                                 ///< Accelerometer data object
   Adafruit_LSM6DS_Gyro *gyro_sensor = NULL; ///< Gyro data object
 
+  //! buffer for the accelerometer range
+  lsm6ds_accel_range_t accelRangeBuffered = LSM6DS_ACCEL_RANGE_2_G;
+  //! buffer for the gyroscope range
+  lsm6ds_gyro_range_t gyroRangeBuffered = LSM6DS_GYRO_RANGE_250_DPS;
+
 private:
   friend class Adafruit_LSM6DS_Temp; ///< Gives access to private members to
                                      ///< Temp data object

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -144,9 +144,11 @@ public:
   bool begin_I2C(uint8_t i2c_addr = LSM6DS_I2CADDR_DEFAULT,
                  TwoWire *wire = &Wire, int32_t sensorID = 0);
 
-  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI, int32_t sensorID = 0);
+  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI,
+                 uint32_t frequency = 1000000, int32_t sensorID = 0);
   bool begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                 int8_t mosi_pin, int32_t sensorID = 0);
+                 int8_t mosi_pin, uint32_t frequency = 1000000,
+                 int32_t sensorID = 0);
 
   bool getEvent(sensors_event_t *accel, sensors_event_t *gyro,
                 sensors_event_t *temp);

--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -144,11 +144,11 @@ public:
   bool begin_I2C(uint8_t i2c_addr = LSM6DS_I2CADDR_DEFAULT,
                  TwoWire *wire = &Wire, int32_t sensorID = 0);
 
-  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI,
-                 uint32_t frequency = 1000000, int32_t sensorID = 0);
+  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI, int32_t sensorID = 0,
+                 uint32_t frequency = 1000000);
   bool begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                 int8_t mosi_pin, uint32_t frequency = 1000000,
-                 int32_t sensorID = 0);
+                 int8_t mosi_pin, int32_t sensorID = 0,
+                 uint32_t frequency = 1000000);
 
   bool getEvent(sensors_event_t *accel, sensors_event_t *gyro,
                 sensors_event_t *temp);


### PR DESCRIPTION
## Allow for custom SPI clock frequency
Added an additional parameter to the SPI constructor, defaults to 1000000 as was before. The chips supports 10Mhz bus frequency. If you want to read out multiple chips with a high sample rate on a busy bus, rising the frequency to the maximum helps removing bottlenecks.

## buffer the accelerometer and gyroscope ranges
Buffering the range instead of requesting it every time the data is read from the chips removes a lot of overhead for a couple of bytes of RAM.

## deleting nullptrs has no effect -> don't check for it
Yeah, don't do it.

## removed two delay()s
Having delay()s in the code is an unwanted (and undocumented) side effect.