### PR TITLE
github-actions: do the more expensive tests last

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -16,17 +16,17 @@ jobs:
          repository: adafruit/ci-arduino
          path: ci
 
-    - name: pre-install
+    - name: Install the prerequisites
       run: bash ci/actions_install.sh
 
-    - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
+    - name: Check for correct code formatting with clang-format
+      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
-    - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
-
-    - name: doxygen
+    - name: Check for correct documentation with doxygen
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         PRETTYNAME : "Adafruit LSM6DS Sensors Library"
       run: bash ci/doxy_gen_and_deploy.sh
+
+    - name: Test the code on supported platforms
+      run: python3 ci/build_platform.py main_platforms


### PR DESCRIPTION
In my experience, the `clang-format` and `doxygen` tests failed the most in my PRs. These are also the least expensive tests, they execute in the range of seconds, but are last checked. You can reasonally expect that the code compiles, but documentation and code formating are hit and miss, especially when different people have different editors and workflows. This saves a lot of execution time on github and gives the users more immediate feedback: 10 out of 13 minutes are the compilation on different platforms you have to wait for until the it fails on a trivial formating or documentation error

Here is a typical log of the workflow:
![Screenshot_20220429_085028](https://user-images.githubusercontent.com/48175951/165898362-e5b0f2d0-a738-4bec-8f81-0df4fffc6b15.png)

Perhaps it is further possible to optimize that by only installing `clang-format` and `doxygen` and executing these test before installing `platformio` (in `pre-install`), which should shave off some more time. I will look into this in the repo adafruit/ci-arduino, but for the time beeing, please consider accepting this PR.