### PR TITLE
Set Block Data Update bit

### DIFF
--- a/Adafruit_ISM330DHCX.cpp
+++ b/Adafruit_ISM330DHCX.cpp
@@ -31,5 +31,12 @@ bool Adafruit_ISM330DHCX::_init(int32_t sensor_id) {
   // call base class _init()
   Adafruit_LSM6DS::_init(sensor_id);
 
+  // set the Block Data Update bit
+  // this prevents MSB/LSB data registers from being updated until both are read
+  Adafruit_BusIO_Register ctrl3 = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_CTRL3_C);
+  Adafruit_BusIO_RegisterBits bdu = Adafruit_BusIO_RegisterBits(&ctrl3, 1, 6);
+  bdu.write(1);
+
   return true;
 }

--- a/Adafruit_LSM6DS3TRC.cpp
+++ b/Adafruit_LSM6DS3TRC.cpp
@@ -31,6 +31,13 @@ bool Adafruit_LSM6DS3TRC::_init(int32_t sensor_id) {
   // call base class _init()
   Adafruit_LSM6DS::_init(sensor_id);
 
+  // set the Block Data Update bit
+  // this prevents MSB/LSB data registers from being updated until both are read
+  Adafruit_BusIO_Register ctrl3 = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_CTRL3_C);
+  Adafruit_BusIO_RegisterBits bdu = Adafruit_BusIO_RegisterBits(&ctrl3, 1, 6);
+  bdu.write(1);
+
   return true;
 }
 

--- a/Adafruit_LSM6DSO32.cpp
+++ b/Adafruit_LSM6DSO32.cpp
@@ -32,6 +32,8 @@ bool Adafruit_LSM6DSO32::_init(int32_t sensor_id) {
 
   reset();
 
+  // set the Block Data Update bit
+  // this prevents MSB/LSB data registers from being updated until both are read
   Adafruit_BusIO_Register ctrl3 = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DSOX_CTRL3_C);
   Adafruit_BusIO_RegisterBits bdu = Adafruit_BusIO_RegisterBits(&ctrl3, 1, 6);

--- a/Adafruit_LSM6DSOX.cpp
+++ b/Adafruit_LSM6DSOX.cpp
@@ -32,6 +32,7 @@ bool Adafruit_LSM6DSOX::_init(int32_t sensor_id) {
   reset();
 
   // Block Data Update
+  // this prevents MSB/LSB data registers from being updated until both are read
   Adafruit_BusIO_Register ctrl3 = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DSOX_CTRL3_C);
   Adafruit_BusIO_RegisterBits bdu = Adafruit_BusIO_RegisterBits(&ctrl3, 1, 6);


### PR DESCRIPTION
This fixes an issue that was originally brought up in emails. Adds setting of the Block Data Update bit for the ISM330DHCX and LSM6DS3TRC.

![image](https://github.com/adafruit/Adafruit_LSM6DS/assets/8755041/3b9d3868-ab5a-4f09-af27-a6e65d767daf)

This was already in place for other sensor variants, so only added some code comments to those.

Example test for ISM330DHCX:
```cpp
#include <Adafruit_ISM330DHCX.h>

Adafruit_ISM330DHCX ism330dhcx;

void setup(void) {
  Serial.begin(115200);
  while (!Serial);
  Serial.println("Adafruit ISM330DHCX test!");

  if (!ism330dhcx.begin_I2C()) {
    Serial.println("Failed to find ISM330DHCX chip");
    while (1);
  }
  Serial.println("ISM330DHCX Found!");

  ism330dhcx.setAccelRange(LSM6DS_ACCEL_RANGE_4_G);
  ism330dhcx.setGyroRange(LSM6DS_GYRO_RANGE_1000_DPS);

  ism330dhcx.setAccelDataRate(LSM6DS_RATE_6_66K_HZ);
  ism330dhcx.setGyroDataRate(LSM6DS_RATE_6_66K_HZ);
}

void loop() {
  sensors_event_t accel;
  sensors_event_t gyro;
  sensors_event_t temp;
  ism330dhcx.getEvent(&accel, &gyro, &temp);

  Serial.print(gyro.gyro.x);
  Serial.print(","); Serial.print(gyro.gyro.y);
  Serial.print(","); Serial.print(gyro.gyro.z);
  Serial.println();
}
```

**BEFORE**
![Screenshot from 2024-04-22 10-15-44](https://github.com/adafruit/Adafruit_LSM6DS/assets/8755041/64e38b76-4c73-4553-8e0e-fe256f29e914)


**AFTER**
![Screenshot from 2024-04-22 10-16-24](https://github.com/adafruit/Adafruit_LSM6DS/assets/8755041/d011bbf2-efcc-4b10-87c7-2df1ffb44a56)


