### PR TITLE
Fix bug where `begin()` would return false even on success

### DIFF
--- a/Adafruit_LSM6DS.cpp
+++ b/Adafruit_LSM6DS.cpp
@@ -80,7 +80,7 @@ bool Adafruit_LSM6DS::_init(int32_t sensor_id) {
   accel_sensor = new Adafruit_LSM6DS_Accelerometer(this);
   gyro_sensor = new Adafruit_LSM6DS_Gyro(this);
 
-  return false;
+  return true;
 };
 
 /*!


### PR DESCRIPTION
Very simple change to fix a very simple bug where `LSM6DS::begin()` wouldn't return true even if it succeeded.