### PR TITLE
Update docs for LSM6DS base class

### DIFF
--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -133,8 +133,9 @@ private:
 };
 
 /*!
- *    @brief  Class that stores state and functions for interacting with
- *            the LSM6DS I2C Accel/Gyro
+ *    @brief  Base class for use with LSM6DS series acclerometer gyro sensors
+ * from STMicroelectronics. DO NOT USE DIRECTLY. Specific sensor variants should
+ * be subclassed as needed.
  */
 class Adafruit_LSM6DS {
 public:


### PR DESCRIPTION
This is just a documentation update.

It more explicitly calls out `LSM6DS` as being a base class. See #43 for more context.